### PR TITLE
feat(ws): add support for custom agent in WebSocket connection

### DIFF
--- a/src/lib/BaseWSClient.ts
+++ b/src/lib/BaseWSClient.ts
@@ -411,7 +411,10 @@ export abstract class BaseWebsocketClient<
       wsKey,
     });
 
-    const ws = new WebSocket(url, undefined);
+    const ws = new WebSocket(
+      url,
+      this.options.agent ? { agent: this.options.agent } : undefined,
+    );
 
     ws.onopen = (event: any) => this.onWsOpen(event, wsKey);
     ws.onmessage = (event: any) => this.onWsMessage(event, wsKey, ws);

--- a/src/types/websockets/client.ts
+++ b/src/types/websockets/client.ts
@@ -1,3 +1,5 @@
+import { Agent } from 'node:http';
+
 /** General configuration for the WebsocketClient */
 export interface WSClientConfigurableOptions {
   /** Your API key */
@@ -23,6 +25,7 @@ export interface WSClientConfigurableOptions {
 
   wsUrl?: string;
 
+  agent?: Agent | undefined;
   /**
    * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
    *


### PR DESCRIPTION
- Updated WebSocket initialization to use a custom  if provided in options.
- Ensures that users can pass an HTTP or HTTPS agent for advanced connection configurations.